### PR TITLE
[feat] 유저 인증을 위한 Argument Resolver 적용

### DIFF
--- a/src/main/java/com/spectrum/auth/JwtProperties.java
+++ b/src/main/java/com/spectrum/auth/JwtProperties.java
@@ -1,0 +1,29 @@
+package com.spectrum.auth;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Validated
+@ConstructorBinding
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    @NotEmpty
+    private final String secretKey;
+    @NotNull
+    private final long accessTokenExpireLength;
+    @NotNull
+    private final long refreshTokenExpireLength;
+
+    public JwtProperties(String secretKey, long accessTokenExpireLength,
+        long refreshTokenExpireLength) {
+        this.secretKey = secretKey;
+        this.accessTokenExpireLength = accessTokenExpireLength;
+        this.refreshTokenExpireLength = refreshTokenExpireLength;
+    }
+}

--- a/src/main/java/com/spectrum/auth/OAuthProperties.java
+++ b/src/main/java/com/spectrum/auth/OAuthProperties.java
@@ -2,14 +2,17 @@ package com.spectrum.auth;
 
 import com.spectrum.auth.dto.ProviderPropertiesDto;
 import com.spectrum.auth.dto.UserPropertiesDto;
-import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
+@ConstructorBinding
+@RequiredArgsConstructor
 @ConfigurationProperties(prefix = "oauth2")
 public class OAuthProperties {
-    private final Map<String, UserPropertiesDto> user = new HashMap<>();
-    private final Map<String, ProviderPropertiesDto> provider = new HashMap<>();
+    private final Map<String, UserPropertiesDto> user;
+    private final Map<String, ProviderPropertiesDto> provider;
 }

--- a/src/main/java/com/spectrum/auth/dto/ProviderPropertiesDto.java
+++ b/src/main/java/com/spectrum/auth/dto/ProviderPropertiesDto.java
@@ -1,12 +1,15 @@
 package com.spectrum.auth.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class ProviderPropertiesDto {
 
-    private String tokenUri;
-    private String userInfoUri;
+    private final String tokenUri;
+    private final String userInfoUri;
+
+    public ProviderPropertiesDto(String tokenUri, String userInfoUri) {
+        this.tokenUri = tokenUri;
+        this.userInfoUri = userInfoUri;
+    }
 }

--- a/src/main/java/com/spectrum/auth/dto/UserPropertiesDto.java
+++ b/src/main/java/com/spectrum/auth/dto/UserPropertiesDto.java
@@ -1,14 +1,17 @@
 package com.spectrum.auth.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class UserPropertiesDto {
 
-    private String clientId;
-    private String clientSecret;
-    private String RedirectUri;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
 
+    public UserPropertiesDto(String clientId, String clientSecret, String redirectUri) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
 }

--- a/src/main/java/com/spectrum/auth/provider/JwtProvider.java
+++ b/src/main/java/com/spectrum/auth/provider/JwtProvider.java
@@ -37,7 +37,6 @@ public class JwtProvider {
 
     public String createToken(String payload, long expireLength) {
         Claims claims = Jwts.claims().setSubject(payload);
-        claims.put("id", payload);
         Date now = new Date();
         Date validity = new Date(now.getTime() + expireLength);
 

--- a/src/main/java/com/spectrum/auth/provider/JwtProvider.java
+++ b/src/main/java/com/spectrum/auth/provider/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.spectrum.auth.provider;
 
+import com.spectrum.exception.auth.InvalidTokenException;
+import com.spectrum.exception.auth.TokenExpiredException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JwtProvider {
+
     @Value("${jwt.access-token.expire-length}")
     private long accessTokenValidityInMilliseconds;
     @Value("${jwt.refresh-token.expire-length}")
@@ -23,25 +26,18 @@ public class JwtProvider {
     public JwtProvider(@Value("${jwt.token.secret-key}") String secretKey) {
         this.secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
     }
+
     public String createAccessToken(String payload) {
-        return createToken(payload, accessTokenValidityInMilliseconds);
+        return createToken(String.valueOf(payload), accessTokenValidityInMilliseconds);
     }
 
     public String createRefreshToken(String payload) {
-        Claims claims = Jwts.claims().setSubject(payload);
-        Date now = new Date();
-        Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
-
-        return Jwts.builder()
-            .setClaims(claims)
-            .setIssuedAt(now)
-            .setExpiration(validity)
-            .signWith(secretKey)
-            .compact();
+        return createToken(String.valueOf(payload), refreshTokenValidityInMilliseconds);
     }
 
     public String createToken(String payload, long expireLength) {
         Claims claims = Jwts.claims().setSubject(payload);
+        claims.put("id", payload);
         Date now = new Date();
         Date validity = new Date(now.getTime() + expireLength);
 
@@ -55,21 +51,31 @@ public class JwtProvider {
 
     public String getPayload(String token) {
         try {
-            return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody().getSubject();
+            return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
         } catch (ExpiredJwtException e) {
-            return e.getClaims().getSubject();
+            throw new TokenExpiredException();
         } catch (JwtException e) {
-            throw new RuntimeException("유효하지 않은 토큰입니다.");
+            throw new InvalidTokenException();
         }
     }
 
     public boolean validateToken(String token) {
         try {
-            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
-
+            Jws<Claims> claims = Jwts
+                .parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
             return !claims.getBody().getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
         } catch (JwtException | IllegalArgumentException e) {
-            return false;
+            throw new InvalidTokenException();
         }
     }
 }

--- a/src/main/java/com/spectrum/common/exception/ErrorCodeAndMessage.java
+++ b/src/main/java/com/spectrum/common/exception/ErrorCodeAndMessage.java
@@ -6,9 +6,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCodeAndMessage {
 
-    SERVER_ERROR("S501 - Internal Server Error", "서버 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    INVALID_REQUEST("F402 - Invalid Request", "요청 정보를 확인해주세요.", HttpStatus.BAD_REQUEST),
-    POST_NOT_FOUND("P401 - Post Not Found", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    SERVER_ERROR("S500 - Internal Server Error", "서버 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_REQUEST("F400 - Invalid Request", "요청 정보를 확인해주세요.", HttpStatus.BAD_REQUEST),
+    POST_NOT_FOUND("P404 - Post Not Found", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_USER("U401 - Invalid User", "유효하지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    USER_NOT_FOUND("U404 - User Not Found", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOT_AUTHOR("A403 - Not Author", "작성자가 아닙니다.", HttpStatus.FORBIDDEN),
+    TOKEN_EXPIRED("T401 - Token Expired", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("T400 - Invalid Token", "유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),
+    HTTP_SERVLET_REQUEST_NULL("H400 - HttpServletRequest Null", "HttpServletRequest가 null입니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/spectrum/common/resolver/CurrentUser.java
+++ b/src/main/java/com/spectrum/common/resolver/CurrentUser.java
@@ -1,0 +1,12 @@
+package com.spectrum.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+
+}

--- a/src/main/java/com/spectrum/common/resolver/UserArgumentResolver.java
+++ b/src/main/java/com/spectrum/common/resolver/UserArgumentResolver.java
@@ -1,0 +1,66 @@
+package com.spectrum.common.resolver;
+
+import com.spectrum.auth.provider.JwtProvider;
+import com.spectrum.exception.auth.InvalidTokenException;
+import com.spectrum.exception.resolver.HttpServletRequestNullException;
+import com.spectrum.exception.user.UserInvalidException;
+import java.util.Objects;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class UserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final static String AUTHORIZATION_HEADER = "Authorization";
+    private final static String TOKEN_TYPE = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(@NonNull MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = Optional.ofNullable(
+                webRequest.getNativeRequest(HttpServletRequest.class))
+            .orElseThrow(HttpServletRequestNullException::new);
+
+        String token = parseAuthorizationHeader(request);
+        if (!jwtProvider.validateToken(token)) {
+            throw new InvalidTokenException();
+        }
+
+        String payload = jwtProvider.getPayload(token);
+        long userId;
+        try {
+            userId = Long.parseLong(payload);
+        } catch (NumberFormatException e) {
+            throw new InvalidTokenException();
+        }
+        return userId;
+    }
+
+    private static String parseAuthorizationHeader(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (Objects.isNull(authorizationHeader) || !authorizationHeader.startsWith(TOKEN_TYPE)) {
+            throw new UserInvalidException();
+        }
+
+        return authorizationHeader.substring(TOKEN_TYPE.length());
+    }
+}

--- a/src/main/java/com/spectrum/config/JwtConfig.java
+++ b/src/main/java/com/spectrum/config/JwtConfig.java
@@ -1,0 +1,13 @@
+package com.spectrum.config;
+
+import com.spectrum.auth.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(JwtProperties.class)
+public class JwtConfig {
+
+}

--- a/src/main/java/com/spectrum/config/WebMvcConfig.java
+++ b/src/main/java/com/spectrum/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.spectrum.config;
+
+import com.spectrum.common.resolver.UserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final UserArgumentResolver userArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userArgumentResolver);
+    }
+}

--- a/src/main/java/com/spectrum/controller/post/PostController.java
+++ b/src/main/java/com/spectrum/controller/post/PostController.java
@@ -1,5 +1,6 @@
 package com.spectrum.controller.post;
 
+import com.spectrum.common.resolver.CurrentUser;
 import com.spectrum.controller.post.dto.PostCreateRequest;
 import com.spectrum.controller.post.dto.PostCreateResponse;
 import com.spectrum.controller.post.dto.PostDetailResponse;
@@ -30,10 +31,10 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<Void> createPost(
-        Long memberId,
+        @CurrentUser Long userId,
         @Valid @RequestBody PostCreateRequest postCreateRequest) {
 
-        PostCreateResponse createdPost = postService.save(memberId,
+        PostCreateResponse createdPost = postService.save(userId,
             postCreateRequest.convertToPostCreateDto());
         URI location = URI.create("/api/posts" + createdPost.getPostId());
         return ResponseEntity.created(location).build();
@@ -41,20 +42,20 @@ public class PostController {
 
     @PutMapping("/{postId}")
     public ResponseEntity<Void> updatePost(
-        Long memberId,
+        @CurrentUser Long userId,
         @PathVariable("postId") Long postId,
         @Valid @RequestBody PostUpdateRequest postUpdateRequest) {
 
-        postService.update(memberId, postId, postUpdateRequest.convertToPostUpdateDto());
+        postService.update(userId, postId, postUpdateRequest.convertToPostUpdateDto());
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
-        Long memberId,
+        @CurrentUser Long userId,
         @PathVariable("postId") Long postId) {
 
-        postService.delete(memberId, postId);
+        postService.delete(userId, postId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/spectrum/controller/post/dto/PostCreateResponse.java
+++ b/src/main/java/com/spectrum/controller/post/dto/PostCreateResponse.java
@@ -10,13 +10,13 @@ import lombok.NoArgsConstructor;
 public class PostCreateResponse {
 
     private Long postId;
-    private Long memberId;
+    private Long userId;
     private String title;
     private String content;
 
-    public PostCreateResponse(Long postId, Long memberId, String title, String content) {
+    public PostCreateResponse(Long postId, Long userId, String title, String content) {
         this.postId = postId;
-        this.memberId = memberId;
+        this.userId = userId;
         this.title = title;
         this.content = content;
     }
@@ -24,7 +24,7 @@ public class PostCreateResponse {
     public static PostCreateResponse ofEntity(Post savePost) {
         return new PostCreateResponse(
             savePost.getId()
-            , savePost.getMemberId()
+            , savePost.getUserId()
             , savePost.getTitle()
             , savePost.getContent());
     }

--- a/src/main/java/com/spectrum/controller/post/dto/PostUpdateResponse.java
+++ b/src/main/java/com/spectrum/controller/post/dto/PostUpdateResponse.java
@@ -11,18 +11,18 @@ public class PostUpdateResponse {
 
     private String title;
     private String content;
-    private Long memberId;
+    private Long userId;
 
-    public PostUpdateResponse(String title, String content, Long memberId) {
+    public PostUpdateResponse(String title, String content, Long userId) {
         this.title = title;
         this.content = content;
-        this.memberId = memberId;
+        this.userId = userId;
     }
 
     public static PostUpdateResponse ofEntity(Post updatePost) {
         return new PostUpdateResponse(
             updatePost.getTitle()
             , updatePost.getContent()
-            , updatePost.getMemberId());
+            , updatePost.getUserId());
     }
 }

--- a/src/main/java/com/spectrum/domain/post/Post.java
+++ b/src/main/java/com/spectrum/domain/post/Post.java
@@ -34,19 +34,19 @@ public class Post extends BaseTimeEntity {
     @Lob
     @Column(nullable = false)
     private String content;
-    private Long memberId;
+    private Long userId;
 
     private LocalDateTime deletedAt;
 
-    public Post(String title, String content, Long memberId) {
+    public Post(String title, String content, Long userId) {
         this.title = title;
         this.content = content;
-        this.memberId = memberId;
+        this.userId = userId;
     }
 
-    public void update(String title, String content, Long memberId) {
+    public void update(String title, String content, Long userId) {
         this.title = title;
         this.content = content;
-        this.memberId = memberId;
+        this.userId = userId;
     }
 }

--- a/src/main/java/com/spectrum/exception/auth/InvalidTokenException.java
+++ b/src/main/java/com/spectrum/exception/auth/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.spectrum.exception.auth;
+
+import com.spectrum.common.exception.ErrorCodeAndMessage;
+import com.spectrum.common.exception.SpectrumRuntimeException;
+
+public class InvalidTokenException extends SpectrumRuntimeException {
+
+    public InvalidTokenException() {
+        super(ErrorCodeAndMessage.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/spectrum/exception/auth/TokenExpiredException.java
+++ b/src/main/java/com/spectrum/exception/auth/TokenExpiredException.java
@@ -1,0 +1,11 @@
+package com.spectrum.exception.auth;
+
+import com.spectrum.common.exception.ErrorCodeAndMessage;
+import com.spectrum.common.exception.SpectrumRuntimeException;
+
+public class TokenExpiredException extends SpectrumRuntimeException {
+
+    public TokenExpiredException() {
+        super(ErrorCodeAndMessage.TOKEN_EXPIRED);
+    }
+}

--- a/src/main/java/com/spectrum/exception/post/NotAuthorException.java
+++ b/src/main/java/com/spectrum/exception/post/NotAuthorException.java
@@ -1,0 +1,11 @@
+package com.spectrum.exception.post;
+
+import com.spectrum.common.exception.ErrorCodeAndMessage;
+import com.spectrum.common.exception.SpectrumRuntimeException;
+
+public class NotAuthorException extends SpectrumRuntimeException {
+
+    public NotAuthorException() {
+        super(ErrorCodeAndMessage.NOT_AUTHOR);
+    }
+}

--- a/src/main/java/com/spectrum/exception/resolver/HttpServletRequestNullException.java
+++ b/src/main/java/com/spectrum/exception/resolver/HttpServletRequestNullException.java
@@ -1,0 +1,11 @@
+package com.spectrum.exception.resolver;
+
+import com.spectrum.common.exception.ErrorCodeAndMessage;
+import com.spectrum.common.exception.SpectrumRuntimeException;
+
+public class HttpServletRequestNullException extends SpectrumRuntimeException {
+
+    public HttpServletRequestNullException() {
+        super(ErrorCodeAndMessage.HTTP_SERVLET_REQUEST_NULL);
+    }
+}

--- a/src/main/java/com/spectrum/exception/user/UserInvalidException.java
+++ b/src/main/java/com/spectrum/exception/user/UserInvalidException.java
@@ -1,0 +1,11 @@
+package com.spectrum.exception.user;
+
+import com.spectrum.common.exception.ErrorCodeAndMessage;
+import com.spectrum.common.exception.SpectrumRuntimeException;
+
+public class UserInvalidException extends SpectrumRuntimeException {
+
+    public UserInvalidException() {
+        super(ErrorCodeAndMessage.INVALID_USER);
+    }
+}

--- a/src/main/java/com/spectrum/exception/user/UserNotFoundException.java
+++ b/src/main/java/com/spectrum/exception/user/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.spectrum.exception.user;
+
+import com.spectrum.common.exception.ErrorCodeAndMessage;
+import com.spectrum.common.exception.SpectrumRuntimeException;
+
+public class UserNotFoundException extends SpectrumRuntimeException {
+
+    public UserNotFoundException() {
+        super(ErrorCodeAndMessage.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/spectrum/service/dto/PostCreateDto.java
+++ b/src/main/java/com/spectrum/service/dto/PostCreateDto.java
@@ -13,7 +13,7 @@ public class PostCreateDto {
         this.content = content;
     }
 
-    public Post convertToEntity(Long memberId) {
-        return new Post(title, content, memberId);
+    public Post convertToEntity(Long userId) {
+        return new Post(title, content, userId);
     }
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -474,9 +474,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/posts HTTP/1.1
-Accept: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWQiOiIxIiwiaWF0IjoxNjc5MDc3MzY4LCJleHAiOjE2NzkwNzc5Njh9.kJVvIDJCczM3EAlOf8QeXcFdixrf57jw2-zD-lfFM-w
 Content-Type: application/json
-Host: localhost:64772
+Host: localhost:59067
 Content-Length: 48
 
 {
@@ -491,8 +491,8 @@ Content-Length: 48
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
-Location: /api/posts3
-Date: Tue, 07 Mar 2023 09:51:17 GMT
+Location: /api/posts5
+Date: Fri, 17 Mar 2023 18:22:48 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive</code></pre>
 </div>
@@ -508,10 +508,11 @@ Connection: keep-alive</code></pre>
 <h4 id="_request_2"><a class="link" href="#_request_2">1.2.1. Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /api/posts/2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /api/posts/11 HTTP/1.1
 Accept: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWQiOiIxIiwiaWF0IjoxNjc5MDc3MzY4LCJleHAiOjE2NzkwNzc5Njh9.kJVvIDJCczM3EAlOf8QeXcFdixrf57jw2-zD-lfFM-w
 Content-Type: application/json
-Host: localhost:64772
+Host: localhost:59067
 Content-Length: 48
 
 {
@@ -526,7 +527,7 @@ Content-Length: 48
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Date: Tue, 07 Mar 2023 09:51:17 GMT
+Date: Fri, 17 Mar 2023 18:22:48 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive</code></pre>
 </div>
@@ -542,10 +543,11 @@ Connection: keep-alive</code></pre>
 <h4 id="_request_3"><a class="link" href="#_request_3">1.3.1. Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/posts/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/posts/8 HTTP/1.1
 Accept: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWQiOiIxIiwiaWF0IjoxNjc5MDc3MzY4LCJleHAiOjE2NzkwNzc5Njh9.kJVvIDJCczM3EAlOf8QeXcFdixrf57jw2-zD-lfFM-w
 Content-Type: application/json
-Host: localhost:64772</code></pre>
+Host: localhost:59067</code></pre>
 </div>
 </div>
 </div>
@@ -554,7 +556,7 @@ Host: localhost:64772</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
-Date: Tue, 07 Mar 2023 09:51:17 GMT
+Date: Fri, 17 Mar 2023 18:22:48 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive</code></pre>
 </div>
@@ -570,10 +572,10 @@ Connection: keep-alive</code></pre>
 <h4 id="_request_4"><a class="link" href="#_request_4">1.4.1. Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/posts/2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/posts/7 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:64772</code></pre>
+Host: localhost:59067</code></pre>
 </div>
 </div>
 </div>
@@ -584,13 +586,13 @@ Host: localhost:64772</code></pre>
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Tue, 07 Mar 2023 09:51:17 GMT
+Date: Fri, 17 Mar 2023 18:22:48 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 66
 
 {
-  "postId" : 2,
+  "postId" : 7,
   "title" : "title2",
   "content" : "content2"
 }</code></pre>
@@ -610,7 +612,7 @@ Content-Length: 66
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/posts HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:64772</code></pre>
+Host: localhost:59067</code></pre>
 </div>
 </div>
 </div>
@@ -621,7 +623,7 @@ Host: localhost:64772</code></pre>
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Tue, 07 Mar 2023 09:51:17 GMT
+Date: Fri, 17 Mar 2023 18:22:48 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 170
@@ -647,7 +649,7 @@ Content-Length: 170
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-03-07 17:40:49 +0900
+Last updated 2023-03-18 03:21:44 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #28 

<br>

### 📝 구현 내용
사용자 인증 절차를 간소화하고 코드 재사용성을 높이기 위해 Argument Resolver를 적용하였습니다.

주요 변경 사항:

- OAuth 로그인 인증 처리에서 해당 유저인지 체크하는 부분을 argument resolver를 사용하여 해결하였습니다.

- argument resolver를 처음 적용하다보니까 실수가 잦았습니다.

- 계속 적용이 안되길래 뭐가 문제인지 몰랐었는데, WebMvcConfigurer 추가를 안해줬었습니다ㅠㅠ

- 커스텀 예외 처리가 안되어있던 부분에 적용해주었습니다.

- 게시글 추가, 생성, 삭제시에 작성자인지, 유효한 유저 확인하는 테스트케이스를 추가

- OAuthProperties DTO에서 setter를 제거하고 생성자 주입으로 수정

- ProviderPropertiesDto와 UserPropertiesDto에서 final 키워드를 추가하여 불변성을 보장하도록 수정

- JwtProperties에서 생성자 주입 방식을 사용하도록 수정

- JwtProvider에서 생성자 주입 방식을 사용하도록 수정

- JwtProperties에 validation 어노테이션 추가하여 값이 null이거나 비어있는 경우 예외를 발생시키도록 구현

<br>

### 💡 결과 & 참고 자료 
- 작성자인지, 가입된 유저인지 확인하는 테스트 케이스 추가
![](https://meenzino.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F4cc90959-114c-48cd-994d-485fdacf3220%2FUntitled.png?id=5caada65-4f0e-479f-a781-4bc69c0f4338&table=block&spaceId=9d32437f-ad77-480c-94b0-229d3642279b&width=350&userId=&cache=v2)

- 컨트롤러 테스트 헤더에 Authorization 추가
[Authorization 추가된 api 문서 링크](http://mj-zino.site/docs/index.html)
![](https://meenzino.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2Ff77b996c-1ae8-4546-b50d-0e3ac01cc196%2FUntitled.png?id=8fb4a256-d50e-452a-967d-ae35f1cda502&table=block&spaceId=9d32437f-ad77-480c-94b0-229d3642279b&width=350&userId=&cache=v2)
![](https://meenzino.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F0244adca-dd29-4618-af12-6cabbd52eb2a%2FUntitled.png?id=79a72d95-c68c-4353-8f56-809346eb09a8&table=block&spaceId=9d32437f-ad77-480c-94b0-229d3642279b&width=600&userId=&cache=v2)
